### PR TITLE
class: change access from private to public

### DIFF
--- a/classes/survey.class.php
+++ b/classes/survey.class.php
@@ -22,7 +22,7 @@
 class UCCASS_Survey extends UCCASS_Main {
 
 
-    private $survey_name = '';
+    public $survey_name = '';
 
     /**
      * Get available surveys (html)


### PR DESCRIPTION
changed the access mode, seems to be written for older php setup, it was throwing the corresponding errors:
system info: Apache/2.4.58 (Unix) OpenSSL/1.1.1w PHP/8.2.12 mod_perl/2.0.12 Perl/v5.34.1

Deprecated: Automatic conversion of false to array is deprecated in /opt/lampp/htdocs/uccass/classes/main.class.php on line 401

Fatal error: Uncaught Error: Cannot access private property UCCASS_Survey::$survey_name in /opt/lampp/htdocs/uccass/survey.php:12 Stack trace: #0 {main} thrown in /opt/lampp/htdocs/uccass/survey.php on line 12